### PR TITLE
Add site sensor to expose Planta room/location

### DIFF
--- a/custom_components/planta/sensor.py
+++ b/custom_components/planta/sensor.py
@@ -146,6 +146,14 @@ PLANT_DESCRIPTORS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:pot-outline",
     ),
+    PlantaSensorEntityDescription(
+        key="site",
+        field="site",
+        translation_key="site",
+        icon="mdi:map-marker",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda plant: plant.get("site", {}).get("name"),
+    ),
 )
 ACTION_DESCRIPTORS = (
     PlantaSensorEntityDescription(

--- a/custom_components/planta/strings.json
+++ b/custom_components/planta/strings.json
@@ -150,6 +150,9 @@
       "scheduled_watering": {
         "name": "Scheduled watering"
       },
+      "site": {
+        "name": "Site"
+      },
       "size": {
         "name": "Size"
       },

--- a/custom_components/planta/translations/de.json
+++ b/custom_components/planta/translations/de.json
@@ -150,6 +150,9 @@
       "scheduled_watering": {
         "name": "Geplante Bewässerung"
       },
+      "site": {
+        "name": "der Standort"
+      },
       "size": {
         "name": "Größe"
       },

--- a/custom_components/planta/translations/de.json
+++ b/custom_components/planta/translations/de.json
@@ -151,7 +151,7 @@
         "name": "Geplante Bewässerung"
       },
       "site": {
-        "name": "der Standort"
+        "name": "Standort"
       },
       "size": {
         "name": "Größe"

--- a/custom_components/planta/translations/en.json
+++ b/custom_components/planta/translations/en.json
@@ -150,6 +150,9 @@
       "scheduled_watering": {
         "name": "Scheduled watering"
       },
+      "site": {
+        "name": "Site"
+      },
       "size": {
         "name": "Size"
       },


### PR DESCRIPTION
This was mostly done with AI. I had a problem where I was moving plants in Planta around my yard/house (yay, spring!) As I did that, the plant entities in HA weren't updating, which was causing issues with irrigation and marking plants as rained. To fix that, I need to determine mismatches between planta and HA. Adding the planta site as a sensor in HA allowed me to do that. 

Further development would automatically move plants, or push a notification if there's a mismatch. 

## Summary

Adds a new diagnostic sensor per plant that exposes the Planta site
(room/location) as `sensor.<plant>_site`.

The integration already fetches `plant["site"]["name"]` and uses it for
`suggested_area` at device registration, but HA only applies
`suggested_area` on first creation. After that, changes in the Planta
app are invisible to HA.

This sensor surfaces the Planta-side site name so users can:
- See where Planta thinks each plant is
- Detect mismatches between Planta sites and HA areas
- Build automations that react to plant location changes

## Changes

- **sensor.py** — one `PlantaSensorEntityDescription` added to
  `PLANT_DESCRIPTORS`
- **strings.json** — one translation key added

## Example

After this change, each plant device gains a sensor like:

| Entity | State |
|---|---|
| `sensor.dumb_cane_site` | `Foyer` |
| `sensor.snake_plant_site` | `Living Room` |

The sensor updates on each coordinator poll, so moving a plant in Planta
is reflected on the next sync.

## Notes

- Uses `value_fn` because `site` is a nested dict (`plant["site"]["name"]`)
  rather than a top-level field
- Marked `EntityCategory.DIAGNOSTIC` to match the existing pattern for
  informational sensors (health, pot type, etc.)
- No breaking changes — existing entities are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Site sensor to show the location assigned to each plant; presented as diagnostic info with a location marker icon for easy identification.

* **Documentation / Translations**
  * Added translations and display name for the new Site sensor (English and German) so it appears correctly in localized UIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/natekspencer/ha-planta/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->