### PR TITLE
Auto remove plants that are no longer available

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,12 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "name": "Home Assistant integration development",
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/python:3.14-bookworm",
   "postCreateCommand": "scripts/setup",
   "postAttachCommand": "scripts/setup",
-  "forwardPorts": [8123],
+  "forwardPorts": [
+    8123
+  ],
   "customizations": {
     "vscode": {
       "extensions": [

--- a/custom_components/planta/coordinator.py
+++ b/custom_components/planta/coordinator.py
@@ -72,13 +72,19 @@ class PlantaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             msg = "Couldn't read from Planta"
             _LOGGER.exception(msg)
             raise UpdateFailed(msg) from ex
+
         if data is None:
             raise ConfigEntryNotReady
 
-        plants = {plant["id"]: plant for plant in data.get("plants", [])}
+        if not isinstance((raw_plants := data.get("plants")), list):
+            raise UpdateFailed("Invalid plant list from Planta")
+
+        plants = {plant["id"]: plant for plant in raw_plants}
         current_plants = {plant_id.split(":")[-1] for plant_id in plants}
 
-        if stale_plants := self.previous_plants - current_plants:
+        if data.get("cursor") is None and (
+            stale_plants := self.previous_plants - current_plants
+        ):
             device_registry = dr.async_get(self.hass)
             for device_id in stale_plants:
                 device = device_registry.async_get_device_by_identifier(

--- a/custom_components/planta/coordinator.py
+++ b/custom_components/planta/coordinator.py
@@ -11,6 +11,7 @@ import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -40,6 +41,17 @@ class PlantaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             always_update=False,
         )
         self.client = client
+        self.previous_plants: set[str] = set()
+
+        # Initialize previous_plants from the device registry so that
+        # stale devices can be detected on the first update after restart.
+        device_registry = dr.async_get(hass)
+        for device in dr.async_entries_for_config_entry(
+            device_registry, config_entry.entry_id
+        ):
+            for domain, identifier in device.identifiers:
+                if domain == DOMAIN:
+                    self.previous_plants.add(identifier)
 
     def get_plant(self, plant_id: str) -> dict[str, Any] | None:
         """Get a plant by it's id."""
@@ -62,7 +74,21 @@ class PlantaCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
             raise UpdateFailed(msg) from ex
         if data is None:
             raise ConfigEntryNotReady
-        return {plant["id"]: plant for plant in data.get("plants", [])}
+
+        plants = {plant["id"]: plant for plant in data.get("plants", [])}
+        current_plants = {plant_id.split(":")[-1] for plant_id in plants}
+
+        if stale_plants := self.previous_plants - current_plants:
+            device_registry = dr.async_get(self.hass)
+            for device_id in stale_plants:
+                device = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, device_id), self.config_entry.entry_id
+                )
+                if device:
+                    device_registry.async_remove_device(device.id)
+        self.previous_plants = current_plants
+
+        return plants
 
     async def async_refresh_plant(self, plant_id: str) -> None:
         """Fetch the latest data for a plant."""

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Planta",
-  "homeassistant": "2024.4.0",
+  "homeassistant": "2026.8.0",
   "render_readme": true,
   "zip_release": true,
   "filename": "planta.zip"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Home Assistant
-homeassistant>=2025.1
+homeassistant>=2026.8
 numpy
 PyTurboJPEG
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed plant devices that are no longer returned by the service, keeping Home Assistant’s device list accurate.
  - Improved synchronization of plant devices during updates.

- **Compatibility**
  - Updated the supported Home Assistant version range to align with newer releases.

- **Chores**
  - Updated the development environment configuration and retained forwarding for port 8123.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->