### PR TITLE
feat: Add todo entity for planta tasks

### DIFF
--- a/custom_components/planta/__init__.py
+++ b/custom_components/planta/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.IMAGE,
     Platform.SENSOR,
+    Platform.TODO,
 ]
 
 

--- a/custom_components/planta/entity.py
+++ b/custom_components/planta/entity.py
@@ -11,6 +11,12 @@ from .const import DOMAIN
 from .coordinator import PlantaCoordinator
 
 
+def get_plant_name(plant: dict) -> str:
+    """Get plant name."""
+    names = plant.get("names", {})
+    return names.get("custom") or names.get("localizedName")
+
+
 class PlantaEntity(CoordinatorEntity[PlantaCoordinator]):
     """Base class for Planta entities."""
 

--- a/custom_components/planta/strings.json
+++ b/custom_components/planta/strings.json
@@ -176,9 +176,20 @@
       }
     },
     "todo": {
-      "tasks": {
-        "name": "Planta tasks"
+      "today": {
+        "name": "Today's tasks"
+      },
+      "upcoming": {
+        "name": "Upcoming tasks"
       }
+    }
+  },
+  "exceptions": {
+    "complete_only": {
+      "message": "Currently, only marking a task as complete is supported."
+    },
+    "invalid_action": {
+      "message": "The {action} action can only be completed in the Planta app at this time."
     }
   }
 }

--- a/custom_components/planta/strings.json
+++ b/custom_components/planta/strings.json
@@ -174,6 +174,11 @@
       "time_since_last_watering": {
         "name": "Time since last watering"
       }
+    },
+    "todo": {
+      "tasks": {
+        "name": "Planta tasks"
+      }
     }
   }
 }

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from datetime import datetime
 import json
 import logging
 from typing import Final
@@ -13,7 +14,7 @@ from homeassistant.components.todo import (
     TodoListEntity,
     TodoListEntityFeature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -26,7 +27,7 @@ from .entity import get_plant_name
 
 _LOGGER = logging.getLogger(__name__)
 
-ACTION_TYPE_SUMMARY_MAP: Final[dict[str, str]] = {
+ACTION_TYPE_MAP: Final[dict[str, str]] = {
     "cleaning": "✨🍃 (Clean)",
     "fertilizing": "🌱💩 (Fertilize)",
     "misting": "💦🌿 (Mist)",
@@ -63,39 +64,46 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{description.key}"
 
     def _todo_items(self) -> Iterator[TodoItem]:
-        now = dt_util.now()
+        today = dt_util.now().date()
 
-        for plant_id, plant_data in self.coordinator.data.items():
-            actions = plant_data.get("actions") or {}
+        for plant_id, plant in self.coordinator.data.items():
+            if not (actions := plant.get("actions")) or not isinstance(actions, dict):
+                continue
+
+            plant_name = get_plant_name(plant)
+            site_name = plant.get("site", {}).get("name")
+
             for action_type, details in actions.items():
                 if not isinstance(details, dict):
                     continue
-                if not (next_action := details.get("next")):
-                    continue
-                if not (date_str := next_action.get("date")):
-                    continue
-                if not (due := dt_util.parse_date(date_str[:10])) or due > now.date():
+
+                status = TodoItemStatus.NEEDS_ACTION
+                completed: datetime | None = None
+                if (
+                    (completed_str := (details.get("completed") or {}).get("date"))
+                    and (completed := dt_util.parse_datetime(completed_str))
+                    and completed.astimezone(dt_util.DEFAULT_TIME_ZONE).date() == today
+                ):
+                    due = today
+                    status = TodoItemStatus.COMPLETED
+                elif (
+                    not (next_action := details.get("next"))
+                    or not (date_str := next_action.get("date"))
+                    or not (due := dt_util.parse_date(date_str[:10]))
+                    or due > today
+                ):
                     continue
 
-                completed_str = (details.get("completed") or {}).get("date")
-                completed = (
-                    dt_util.parse_datetime(completed_str) if completed_str else None
-                )
+                action_name = ACTION_TYPE_MAP.get(action_type, action_type.title())
 
                 yield TodoItem(
-                    summary=f"{get_plant_name(plant_data)}: {ACTION_TYPE_SUMMARY_MAP.get(action_type, action_type.title())}",
+                    summary=f"{plant_name}: {action_name}",
                     uid=json.dumps((plant_id, action_type)),
-                    status=TodoItemStatus.NEEDS_ACTION,
+                    status=status,
                     due=due,
-                    description=plant_data["site"]["name"],
+                    description=site_name,
                     completed=completed,
                 )
-
-    @property
-    def todo_items(self) -> list[TodoItem] | None:
-        """Get the current set of To-do items."""
-        items = list(self._todo_items())
-        return sorted(items, key=lambda t: (t.due, t.description, t.summary))
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
@@ -106,3 +114,15 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
         plant_id, action_type = json.loads(item.uid)
         await self.coordinator.client.plant_action_complete(plant_id, action_type)
         await self.coordinator.async_refresh_plant(plant_id)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        items = list(self._todo_items())
+        items = sorted(items, key=lambda t: (t.due, t.description, t.summary))
+        self._attr_todo_items = items
+        super()._handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        self._handle_coordinator_update()
+        await super().async_added_to_hass()

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -70,17 +70,11 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
             for action_type, details in actions.items():
                 if not isinstance(details, dict):
                     continue
-
-                next_action = details.get("next")
-                if not next_action:
+                if not (next_action := details.get("next")):
                     continue
-
-                date_str = next_action.get("date")
-                if not date_str:
+                if not (date_str := next_action.get("date")):
                     continue
-
-                due = dt_util.parse_date(date_str[:10])
-                if due > now.date():
+                if not (due := dt_util.parse_date(date_str[:10])) or due > now.date():
                     continue
 
                 completed_str = (details.get("completed") or {}).get("date")

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -1,0 +1,114 @@
+"""Planta todo entity."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+import json
+import logging
+from typing import Final
+
+from homeassistant.components.todo import (
+    TodoItem,
+    TodoItemStatus,
+    TodoListEntity,
+    TodoListEntityFeature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+import homeassistant.util.dt as dt_util
+
+from . import PlantaConfigEntry
+from .coordinator import PlantaCoordinator
+from .entity import get_plant_name
+
+_LOGGER = logging.getLogger(__name__)
+
+ACTION_TYPE_SUMMARY_MAP: Final[dict[str, str]] = {
+    "cleaning": "✨🍃 (Clean)",
+    "fertilizing": "🌱💩 (Fertilize)",
+    "misting": "💦🌿 (Mist)",
+    "progressUpdate": "📸🌸 (Progress update)",
+    "repotting": "🪴🔄 (Repot)",
+    "watering": "🪴💧 (Water)",
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PlantaConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Planta todo using config entry."""
+    async_add_entities([PlantaTodoListEntity(entry.runtime_data, TODO)])
+
+
+TODO = EntityDescription(key="todo", translation_key="tasks")
+
+
+class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity):
+    """Planta todo list entity."""
+
+    _attr_has_entity_name = True
+    _attr_supported_features = TodoListEntityFeature.UPDATE_TODO_ITEM
+
+    def __init__(
+        self, coordinator: PlantaCoordinator, description: EntityDescription
+    ) -> None:
+        """Construct a Planta to-do list entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{description.key}"
+
+    def _todo_items(self) -> Iterator[TodoItem]:
+        now = dt_util.now()
+
+        for plant_id, plant_data in self.coordinator.data.items():
+            actions = plant_data.get("actions") or {}
+            for action_type, details in actions.items():
+                if not isinstance(details, dict):
+                    continue
+
+                next_action = details.get("next")
+                if not next_action:
+                    continue
+
+                date_str = next_action.get("date")
+                if not date_str:
+                    continue
+
+                due = dt_util.parse_date(date_str[:10])
+                if due > now.date():
+                    continue
+
+                completed_str = (details.get("completed") or {}).get("date")
+                completed = (
+                    dt_util.parse_datetime(completed_str) if completed_str else None
+                )
+
+                yield TodoItem(
+                    summary=f"{get_plant_name(plant_data)}: {ACTION_TYPE_SUMMARY_MAP.get(action_type, action_type.title())}",
+                    uid=json.dumps((plant_id, action_type)),
+                    status=TodoItemStatus.NEEDS_ACTION,
+                    due=due,
+                    description=plant_data["site"]["name"],
+                    completed=completed,
+                )
+
+    @property
+    def todo_items(self) -> list[TodoItem] | None:
+        """Get the current set of To-do items."""
+        items = list(self._todo_items())
+        return sorted(items, key=lambda t: (t.due, t.description, t.summary))
+
+    async def async_update_todo_item(self, item: TodoItem) -> None:
+        """Update a To-do item."""
+        if not item.status == TodoItemStatus.COMPLETED:
+            raise ServiceValidationError(
+                "Currently, only marking a task as complete is supported"
+            )
+        plant_id, action_type = json.loads(item.uid)
+        await self.coordinator.client.plant_action_complete(plant_id, action_type)
+        await self.coordinator.async_refresh_plant(plant_id)

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -42,11 +42,16 @@ ALLOWED_ACTIONS: Final[set[str]] = {"cleaning", "fertilizing", "misting", "water
 TODO_LISTS = ("today", "upcoming")
 
 
+def _today() -> date:
+    """Return today's date."""
+    return dt_util.now().date()
+
+
 def _todo_items(
     coordinator: PlantaCoordinator,
 ) -> Iterator[tuple[date, TodoItem]]:
     """Yield to-do items."""
-    today = dt_util.now().date()
+    today = _today()
 
     for plant_id, plant in coordinator.data.items():
         if not (actions := plant.get("actions")) or not isinstance(actions, dict):
@@ -109,7 +114,7 @@ def _get_todo_items(
     end_days: int | None = None,
 ) -> Iterator[TodoItem]:
     """Yield to-do items whose date falls within the window."""
-    today = dt_util.now().date()
+    today = _today()
     lo = today + timedelta(days=start_days) if start_days is not None else None
     hi = today + timedelta(days=end_days) if end_days is not None else None
 
@@ -147,6 +152,16 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
         )
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{key}"
 
+        self._today: date | None = None
+
+    @property
+    @override
+    def todo_items(self) -> list[TodoItem] | None:
+        """Return the To-do items in the To-do list."""
+        if self._today != _today():
+            self._handle_coordinator_update()
+        return self._attr_todo_items
+
     @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
@@ -173,6 +188,7 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
         items = list(_get_todo_items(self.coordinator, start_days=start, end_days=end))
         items = sorted(items, key=lambda t: (t.due, t.description or "", t.summary))
         self._attr_todo_items = items
+        self._today = _today()
         super()._handle_coordinator_update()
 
     @override

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -1,12 +1,12 @@
-"""Planta todo entity."""
+"""Planta to-do list entity."""
 
 from __future__ import annotations
 
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import date, timedelta
 import json
 import logging
-from typing import Final
+from typing import Final, override
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -16,25 +16,106 @@ from homeassistant.components.todo import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import homeassistant.util.dt as dt_util
 
 from . import PlantaConfigEntry
+from .const import DOMAIN
 from .coordinator import PlantaCoordinator
 from .entity import get_plant_name
 
 _LOGGER = logging.getLogger(__name__)
 
 ACTION_TYPE_MAP: Final[dict[str, str]] = {
-    "cleaning": "✨🍃 (Clean)",
-    "fertilizing": "🌱💩 (Fertilize)",
-    "misting": "💦🌿 (Mist)",
-    "progressUpdate": "📸🌸 (Progress update)",
-    "repotting": "🪴🔄 (Repot)",
-    "watering": "🪴💧 (Water)",
+    "cleaning": "✨🍃 Clean",
+    "fertilizing": "🌱💩 Fertilize",
+    "misting": "💦🌿 Mist",
+    "progressUpdate": "📸🌸 Progress update",
+    "repotting": "🪴🔄 Repot",
+    "watering": "🪴💧 Water",
 }
+ALLOWED_ACTIONS: Final[set[str]] = {"cleaning", "fertilizing", "misting", "watering"}
+
+TODO_LISTS = ("today", "upcoming")
+
+
+def _todo_items(
+    coordinator: PlantaCoordinator,
+) -> Iterator[tuple[date, TodoItem]]:
+    """Yield to-do items."""
+    today = dt_util.now().date()
+
+    for plant_id, plant in coordinator.data.items():
+        if not (actions := plant.get("actions")) or not isinstance(actions, dict):
+            continue
+
+        plant_name = get_plant_name(plant)
+        site_name = plant.get("site", {}).get("name")
+
+        for action_type, details in actions.items():
+            if not isinstance(details, dict):
+                continue
+
+            action_name = ACTION_TYPE_MAP.get(action_type, action_type.title())
+            if action_type not in ALLOWED_ACTIONS:
+                action_name += " (app only)"
+            summary = f"{plant_name}: {action_name}"
+            uid = json.dumps((plant_id, action_type))
+            completed = None
+
+            if (
+                (completed_str := (details.get("completed") or {}).get("date"))
+                and (completed := dt_util.parse_datetime(completed_str))
+                and completed.astimezone(dt_util.DEFAULT_TIME_ZONE).date() == today
+            ):
+                yield (
+                    today,
+                    TodoItem(
+                        summary=summary,
+                        uid=uid,
+                        status=TodoItemStatus.COMPLETED,
+                        due=today,
+                        description=site_name,
+                        completed=completed,
+                    ),
+                )
+
+            if (
+                (next_action := details.get("next") or {})
+                and (date_str := next_action.get("date"))
+                and (next_due := dt_util.parse_date(date_str[:10]))
+                and next_due is not None
+            ):
+                yield (
+                    next_due,
+                    TodoItem(
+                        summary=summary,
+                        uid=uid,
+                        status=TodoItemStatus.NEEDS_ACTION,
+                        due=next_due,
+                        description=site_name,
+                        completed=completed,
+                    ),
+                )
+
+
+def _get_todo_items(
+    coordinator: PlantaCoordinator,
+    *,
+    start_days: int | None = None,
+    end_days: int | None = None,
+) -> Iterator[TodoItem]:
+    """Yield to-do items whose date falls within the window."""
+    today = dt_util.now().date()
+    lo = today + timedelta(days=start_days) if start_days is not None else None
+    hi = today + timedelta(days=end_days) if end_days is not None else None
+
+    for window_date, item in _todo_items(coordinator):
+        if (lo is None or window_date >= lo) and (hi is None or window_date <= hi):
+            yield item
 
 
 async def async_setup_entry(
@@ -43,86 +124,59 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Planta todo using config entry."""
-    async_add_entities([PlantaTodoListEntity(entry.runtime_data, TODO)])
-
-
-TODO = EntityDescription(key="todo", translation_key="tasks")
+    async_add_entities(
+        PlantaTodoListEntity(entry.runtime_data, key) for key in TODO_LISTS
+    )
 
 
 class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity):
-    """Planta todo list entity."""
+    """Planta to-do list entity."""
 
     _attr_has_entity_name = True
     _attr_supported_features = TodoListEntityFeature.UPDATE_TODO_ITEM
 
-    def __init__(
-        self, coordinator: PlantaCoordinator, description: EntityDescription
-    ) -> None:
+    def __init__(self, coordinator: PlantaCoordinator, key: str) -> None:
         """Construct a Planta to-do list entity."""
         super().__init__(coordinator)
-        self.entity_description = description
-        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{description.key}"
+        self.entity_description = EntityDescription(key=key, translation_key=key)
 
-    def _todo_items(self) -> Iterator[TodoItem]:
-        today = dt_util.now().date()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_service")},
+            manufacturer="Planta",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{key}"
 
-        for plant_id, plant in self.coordinator.data.items():
-            if not (actions := plant.get("actions")) or not isinstance(actions, dict):
-                continue
-
-            plant_name = get_plant_name(plant)
-            site_name = plant.get("site", {}).get("name")
-
-            for action_type, details in actions.items():
-                if not isinstance(details, dict):
-                    continue
-
-                status = TodoItemStatus.NEEDS_ACTION
-                completed: datetime | None = None
-                if (
-                    (completed_str := (details.get("completed") or {}).get("date"))
-                    and (completed := dt_util.parse_datetime(completed_str))
-                    and completed.astimezone(dt_util.DEFAULT_TIME_ZONE).date() == today
-                ):
-                    due = today
-                    status = TodoItemStatus.COMPLETED
-                elif (
-                    not (next_action := details.get("next"))
-                    or not (date_str := next_action.get("date"))
-                    or not (due := dt_util.parse_date(date_str[:10]))
-                    or due > today
-                ):
-                    continue
-
-                action_name = ACTION_TYPE_MAP.get(action_type, action_type.title())
-
-                yield TodoItem(
-                    summary=f"{plant_name}: {action_name}",
-                    uid=json.dumps((plant_id, action_type)),
-                    status=status,
-                    due=due,
-                    description=site_name,
-                    completed=completed,
-                )
-
+    @override
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update a To-do item."""
         if not item.status == TodoItemStatus.COMPLETED:
             raise ServiceValidationError(
-                "Currently, only marking a task as complete is supported"
+                translation_domain=DOMAIN, translation_key="complete_only"
             )
         plant_id, action_type = json.loads(item.uid)
+        if action_type not in ALLOWED_ACTIONS:
+            action_name = ACTION_TYPE_MAP.get(action_type, action_type.title())
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_action",
+                translation_placeholders={"action": action_name},
+            )
         await self.coordinator.client.plant_action_complete(plant_id, action_type)
         await self.coordinator.async_refresh_plant(plant_id)
 
     @callback
+    @override
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        items = list(self._todo_items())
+        start, end = (None, 0) if self.entity_description.key == "today" else (1, 30)
+        items = list(_get_todo_items(self.coordinator, start_days=start, end_days=end))
         items = sorted(items, key=lambda t: (t.due, t.description or "", t.summary))
         self._attr_todo_items = items
         super()._handle_coordinator_update()
 
+    @override
     async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
         self._handle_coordinator_update()
         await super().async_added_to_hass()

--- a/custom_components/planta/todo.py
+++ b/custom_components/planta/todo.py
@@ -119,7 +119,7 @@ class PlantaTodoListEntity(CoordinatorEntity[PlantaCoordinator], TodoListEntity)
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         items = list(self._todo_items())
-        items = sorted(items, key=lambda t: (t.due, t.description, t.summary))
+        items = sorted(items, key=lambda t: (t.due, t.description or "", t.summary))
         self._attr_todo_items = items
         super()._handle_coordinator_update()
 

--- a/custom_components/planta/translations/en.json
+++ b/custom_components/planta/translations/en.json
@@ -176,9 +176,20 @@
       }
     },
     "todo": {
-      "tasks": {
-        "name": "Planta tasks"
+      "today": {
+        "name": "Today's tasks"
+      },
+      "upcoming": {
+        "name": "Upcoming tasks"
       }
+    }
+  },
+  "exceptions": {
+    "complete_only": {
+      "message": "Currently, only marking a task as complete is supported."
+    },
+    "invalid_action": {
+      "message": "The {action} action can only be completed in the Planta app at this time."
     }
   }
 }

--- a/custom_components/planta/translations/en.json
+++ b/custom_components/planta/translations/en.json
@@ -174,6 +174,11 @@
       "time_since_last_watering": {
         "name": "Time since last watering"
       }
+    },
+    "todo": {
+      "tasks": {
+        "name": "Planta tasks"
+      }
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Planta task lists in Home Assistant for today’s and upcoming plant actions.
  - Displays action labels, due dates, plant details, completion status, and completion timestamps.
  - Supports completing eligible plant actions directly from the task list.
  - Uses custom plant names when available, with localized names as a fallback.
  - Added English labels and translations for the new task entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->